### PR TITLE
Add missing crypto-js dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,6 @@ https://nodejs.org/en/
 命令行
 
 ```bash
+npm i
 node index.js https://www.ximalaya.com/album/4264862 目录(可选)
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,28 @@
 {
   "name": "wing",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wing",
-      "version": "1.0.1",
-      "license": "MIT"
+      "version": "1.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "crypto-js": "^4.2.0"
+      }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
+    }
+  },
+  "dependencies": {
+    "crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
   "bugs": {
     "url": "https://github.com/wing-ho/ximalaya/issues"
   },
-  "homepage": "https://github.com/wing-ho/ximalaya#readme"
+  "homepage": "https://github.com/wing-ho/ximalaya#readme",
+  "dependencies": {
+    "crypto-js": "^4.2.0"
+  }
 }


### PR DESCRIPTION
This PR resolves the `Error: Cannot find module 'crypto-js'` issue, which was due to a dependency on crypto-js.